### PR TITLE
Fix corrupted texts in the tag of GME

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "directory-tree": "^2.2.1",
     "dotenv": "4.0.0",
     "dotenv-expand": "4.2.0",
+    "encoding-japanese": "^1.0.30",
     "eslint": "^5.16.0",
     "eslint-config-react-app": "^4.0.1",
     "eslint-loader": "2.1.2",

--- a/src/players/GMEPlayer.js
+++ b/src/players/GMEPlayer.js
@@ -1,7 +1,7 @@
 import Player from "./Player.js";
 import App from "../App";
 import SubBass from "../effects/SubBass";
-const encoding = require('encoding-japanese');
+import encoding from "encoding-japanese";
 
 let emu = null;
 let libgme = null;

--- a/src/players/GMEPlayer.js
+++ b/src/players/GMEPlayer.js
@@ -1,6 +1,7 @@
 import Player from "./Player.js";
 import App from "../App";
 import SubBass from "../effects/SubBass";
+const encoding = require('encoding-japanese');
 
 let emu = null;
 let libgme = null;
@@ -154,25 +155,18 @@ export default class GMEPlayer extends Player {
     };
 
     const readString = function () {
-      let value = '';
-
-      // Interpret as UTF8 (disabled)
-      // value = libgme.UTF8ToString(libgme.getValue(ref + offset, "i8*"));
-
-      // Interpret as ISO-8859-1 (unsigned integer values, 0 to 255)
+      const raw = [];
       const ptr = libgme.getValue(ref + offset, 'i8*');
       for (let i = 0; i < 255; i++) {
         let char = libgme.getValue(ptr + i, 'i8');
         if (char === 0) {
           break;
-        } else if (char < 0) {
-          char = (Math.abs(char) ^ 255) + 1;
         }
-        value += String.fromCharCode(char);
+        raw.push(char & 0xFF);
       }
 
       offset += 4;
-      return value;
+      return encoding.convert(raw, {to: 'UNICODE', type: 'string'});
     };
 
     const meta = {};


### PR DESCRIPTION
## Overview
GME based files sometimes may show corrupt texts in their tag. 
This is because of the mismatch between internal text encoding in the tags and js. 
This fix brings the text encoding convertor to solve this.

## How to represent the bug
Load the files which include Japanese texts in the tag.

## Screen shots
before
<img width="359" alt="before" src="https://user-images.githubusercontent.com/38772866/67470428-aa9e5880-f688-11e9-802b-450e450ad5ba.png">

after
<img width="326" alt="after" src="https://user-images.githubusercontent.com/38772866/67470479-c275dc80-f688-11e9-8eb2-7be6098aec7b.png">

