### PR TITLE
Fixed incorrect spectrum analyzer area in Chrome

### DIFF
--- a/src/Visualizer.js
+++ b/src/Visualizer.js
@@ -15,6 +15,7 @@ const FFT_SIZES = [
 const FFT_LABELS = [
   '512', '1K', '2K', '4K', '8K', '16K'
 ];
+const VIS_WIDTH = 448;
 
 export default class Visualizer extends PureComponent {
   constructor(props) {
@@ -75,6 +76,8 @@ export default class Visualizer extends PureComponent {
   render() {
     const enabledStyle = {
       display: this.state.enabled ? 'block' : 'none',
+      width: VIS_WIDTH,
+      boxSizing: 'border-box',
     };
     return (
       <div className='Visualizer'>
@@ -142,7 +145,8 @@ export default class Visualizer extends PureComponent {
              ref={this.pianoKeysRef}
              alt='Piano keys'
              style={{
-               display: (this.state.enabled && this.state.vizMode === 2) ? 'block' : 'none'
+               display: (this.state.enabled && this.state.vizMode === 2) ? 'block' : 'none',
+               width: VIS_WIDTH,
              }}/>
       </div>
     );


### PR DESCRIPTION
In Chrome (88.0.4324.96), there is a glitch for spectrum analyzer area.
![スクリーンショット 2021-02-02 19 27 58](https://user-images.githubusercontent.com/38772866/106604117-8b3bee00-65a2-11eb-8038-ca7cceaa703e.png)

I found that the [demo site](https://mmontag.github.io/chip-player-js/) does not have this issue, because there are some differences from the `Visualizer.js` on github.
This is the diffs and will fix the issue on Chrome.